### PR TITLE
Fix dimension references in TestMode

### DIFF
--- a/js/TestMode.js
+++ b/js/TestMode.js
@@ -91,8 +91,8 @@ export class TestMode {
         }
         
         // Apply proper player constraints (same as in player.js)
-        this.player.x = constrain(this.player.x, halfSize, width - halfSize);
-        this.player.y = constrain(this.player.y, halfSize, height - halfSize);
+        this.player.x = constrain(this.player.x, halfSize, this.player.p.width - halfSize);
+        this.player.y = constrain(this.player.y, halfSize, this.player.p.height - halfSize);
     }
     
     // Move player to corners in sequence
@@ -104,38 +104,38 @@ export class TestMode {
             this.player.y = halfSize;
         } else if (cornerPhase < 2) {
             // Top-right corner
-            this.player.x = width - halfSize;
+            this.player.x = this.player.p.width - halfSize;
             this.player.y = halfSize;
         } else if (cornerPhase < 3) {
             // Bottom-right corner
-            this.player.x = width - halfSize;
-            this.player.y = height - halfSize;
+            this.player.x = this.player.p.width - halfSize;
+            this.player.y = this.player.p.height - halfSize;
         } else {
             // Bottom-left corner
             this.player.x = halfSize;
-            this.player.y = height - halfSize;
+            this.player.y = this.player.p.height - halfSize;
         }
     }
     
     // Move along vertical edges (left and right)
     moveAlongVerticalEdges(phase, halfSize) {
         const edgePhase = phase / (Math.PI * 2);
-        this.player.x = edgePhase < 0.5 ? halfSize : width - halfSize; // Left then right edge
-        this.player.y = halfSize + (height - this.player.size) * sin(edgePhase * Math.PI * 4); // Move up/down along edge
+        this.player.x = edgePhase < 0.5 ? halfSize : this.player.p.width - halfSize; // Left then right edge
+        this.player.y = halfSize + (this.player.p.height - this.player.size) * sin(edgePhase * Math.PI * 4); // Move up/down along edge
     }
     
     // Move along horizontal edges (top and bottom)
     moveAlongHorizontalEdges(phase, halfSize) {
         const edgePhase = phase / (Math.PI * 2);
-        this.player.y = edgePhase < 0.5 ? halfSize : height - halfSize; // Top then bottom edge
-        this.player.x = halfSize + (width - this.player.size) * sin(edgePhase * Math.PI * 4); // Move left/right along edge
+        this.player.y = edgePhase < 0.5 ? halfSize : this.player.p.height - halfSize; // Top then bottom edge
+        this.player.x = halfSize + (this.player.p.width - this.player.size) * sin(edgePhase * Math.PI * 4); // Move left/right along edge
     }
     
     // Move in center pattern
     moveCenterPattern(phase, halfSize) {
-        const centerX = width / 2;
-        const centerY = height / 2;
-        const radius = Math.min(width, height) * 0.2;
+        const centerX = this.player.p.width / 2;
+        const centerY = this.player.p.height / 2;
+        const radius = Math.min(this.player.p.width, this.player.p.height) * 0.2;
         this.player.x = centerX + radius * cos(phase * 2);
         this.player.y = centerY + radius * cos(phase * 2);
     }
@@ -202,8 +202,8 @@ export class TestMode {
         if (this.timer - this.lastEnemySpawnFrame < this.enemySpawnInterval) return;
         
         // Spawn test enemy
-        const testX = random(50, width - 50);
-        const testY = random(50, height - 50);
+        const testX = random(50, this.player.p.width - 50);
+        const testY = random(50, this.player.p.height - 50);
         
         // Randomly choose enemy type for testing
         const enemyTypes = ['grunt', 'stabber', 'rusher', 'tank'];
@@ -261,8 +261,8 @@ export class TestMode {
     forceSpawnEnemy(type, x = null, y = null) {
         if (!window.enemies) return;
         
-        const spawnX = x !== null ? x : random(50, width - 50);
-        const spawnY = y !== null ? y : random(50, height - 50);
+        const spawnX = x !== null ? x : random(50, this.player.p.width - 50);
+        const spawnY = y !== null ? y : random(50, this.player.p.height - 50);
         
         if (window.spawnSystem && window.spawnSystem.enemyFactory) {
             const enemy = window.spawnSystem.enemyFactory.createEnemy(spawnX, spawnY, type);


### PR DESCRIPTION
## Summary
- reference the p5 instance's width & height throughout TestMode
- use p5 instance dimensions for center and spawn calculations

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ce5977c8832a98d20130efb37cc1