### PR TITLE
Use relative import map paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,18 +37,18 @@
     <script type="importmap">
       {
         "imports": {
-          "@vibe/core": "/packages/core/src/index.js",
-          "@vibe/core/": "/packages/core/src/",
-          "@vibe/systems": "/packages/systems/src/index.js",
-          "@vibe/systems/": "/packages/systems/src/",
-          "@vibe/entities": "/packages/entities/src/index.js",
-          "@vibe/entities/": "/packages/entities/src/",
-          "@vibe/fx": "/packages/fx/src/index.js",
-          "@vibe/fx/": "/packages/fx/src/",
-          "@vibe/tooling": "/packages/tooling/src/index.js",
-          "@vibe/tooling/": "/packages/tooling/src/",
-          "@vibe/game": "/packages/game/src/index.js",
-          "@vibe/game/": "/packages/game/src/"
+          "@vibe/core": "./packages/core/src/index.js",
+          "@vibe/core/": "./packages/core/src/",
+          "@vibe/systems": "./packages/systems/src/index.js",
+          "@vibe/systems/": "./packages/systems/src/",
+          "@vibe/entities": "./packages/entities/src/index.js",
+          "@vibe/entities/": "./packages/entities/src/",
+          "@vibe/fx": "./packages/fx/src/index.js",
+          "@vibe/fx/": "./packages/fx/src/",
+          "@vibe/tooling": "./packages/tooling/src/index.js",
+          "@vibe/tooling/": "./packages/tooling/src/",
+          "@vibe/game": "./packages/game/src/index.js",
+          "@vibe/game/": "./packages/game/src/"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- use relative `./packages` paths in index.html import map so modules resolve in deployments not at domain root

## Testing
- `bun run lint` *(fails: prettier/prettier violations)*
- `bun run test:playwright` *(fails: 6 failing tests)*
- `bun run test:mcp`


------
https://chatgpt.com/codex/tasks/task_e_689e457dbf88832aa44bd07e7d7ec4cc