### PR TITLE
Refine wormhole effect and spawn enemy fragments

### DIFF
--- a/packages/core/src/Audio.js
+++ b/packages/core/src/Audio.js
@@ -54,6 +54,7 @@ import { random, randomRange, floor, PI } from './mathUtils.js';
 import { SFXManager } from './audio/SFXManager.js';
 import { SOUND } from './audio/SoundIds.js';
 import { withBlendMode } from './render/blendUtils.js';
+import { CONFIG } from './config.js';
 
 export class Audio {
   /**
@@ -322,11 +323,15 @@ export class Audio {
     // Voice configuration - REDUCED VOLUMES for background speech effect
     this.voiceConfig = {
       // Player voice tweaked for mysterious tone
-      player: { rate: 0.85, pitch: 0.15, volume: 0.5 },
-      grunt: { rate: 0.6, pitch: 1.6, volume: 0.45 }, // Increased from 0.3 to 0.45 for better audibility
-      rusher: { rate: 1.4, pitch: 1.5, volume: 0.35 }, // Reduced from 0.9 to 0.35
-      tank: { rate: 0.5, pitch: 0.2, volume: 0.4 }, // Reduced from 1.0 to 0.4
-      stabber: { rate: 0.8, pitch: 2.0, volume: 0.55 }, // Raised volume for better audibility
+      player: {
+        rate: 0.85,
+        pitch: 0.15,
+        volume: CONFIG.SPEECH_VOLUMES.PLAYER,
+      },
+      grunt: { rate: 0.6, pitch: 1.6, volume: CONFIG.SPEECH_VOLUMES.GRUNT },
+      rusher: { rate: 1.4, pitch: 1.5, volume: CONFIG.SPEECH_VOLUMES.RUSHER },
+      tank: { rate: 0.5, pitch: 0.2, volume: CONFIG.SPEECH_VOLUMES.TANK },
+      stabber: { rate: 0.8, pitch: 2.0, volume: CONFIG.SPEECH_VOLUMES.STABBER },
     };
 
     // Initialise dedicated SFX Manager (first extraction step)

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -148,6 +148,13 @@ const CONFIG = {
       CHANT_MAX: 6,
     },
   },
+  SPEECH_VOLUMES: {
+    PLAYER: 0.5,
+    GRUNT: 0.45,
+    RUSHER: 0.55,
+    TANK: 0.4,
+    STABBER: 0.7,
+  },
   STABBER_SETTINGS: {
     MIN_STAB_DISTANCE: 200,
     MAX_STAB_DISTANCE: 350,

--- a/packages/entities/src/BaseEnemy.js
+++ b/packages/entities/src/BaseEnemy.js
@@ -550,6 +550,7 @@ export class BaseEnemy {
    */
   checkCollision(other) {
     const distance = this.p.dist(this.x, this.y, other.x, other.y);
-    return distance < (this.size + other.size) * 0.85;
+    const threshold = (this.size + other.size) * 0.5; // Use radii for consistency
+    return distance < threshold;
   }
 }

--- a/packages/entities/src/Grunt.js
+++ b/packages/entities/src/Grunt.js
@@ -19,6 +19,9 @@ class Grunt extends BaseEnemy {
     this.p = p;
     this.audio = audio;
 
+    // Visual variant for silly shapes
+    this.variant = random() < 0.4 ? 'doubleHead' : 'default';
+
     // --- Deferred-death state ---------------------------------
     this.pendingStabDeath = false; // true while "ow" delay active
     this.pendingStabDeathTimer = 0; // frames remaining
@@ -256,9 +259,14 @@ class Grunt extends BaseEnemy {
    */
   drawBody(s) {
     // Main round body (baby-like proportions)
+    this.p.push();
+    // Slight shift so collision circle matches visuals
+    this.p.translate(-s * 0.05, 0);
     this.p.fill(this.bodyColor);
-    this.p.noStroke();
+    this.p.stroke(0, 0, 0, 80);
+    this.p.strokeWeight(2);
     this.p.ellipse(0, 0, s, s * 0.9); // Rounder baby-like body
+    this.p.noStroke();
 
     // Round baby-like head (larger and rounder)
     this.p.fill(
@@ -266,7 +274,10 @@ class Grunt extends BaseEnemy {
       this.bodyColor.levels[1] + 20,
       this.bodyColor.levels[2] + 20
     );
+    this.p.stroke(0, 0, 0, 80);
+    this.p.strokeWeight(2);
     this.p.ellipse(0, -s * 0.4, s * 0.8, s * 0.8); // Big round baby head
+    this.p.noStroke();
 
     // Simple round helmet (baby helmet style)
     this.p.fill(120, 120, 150); // Gray helmet color
@@ -294,6 +305,23 @@ class Grunt extends BaseEnemy {
     this.p.fill(255);
     this.p.ellipse(-s * 0.12, -s * 0.32, s * 0.06); // Left highlight (bigger)
     this.p.ellipse(s * 0.15, -s * 0.36, s * 0.04); // Right highlight (smaller)
+
+    // Optional goofy second head variant
+    if (this.variant === 'doubleHead') {
+      this.p.fill(
+        this.bodyColor.levels[0] + 20,
+        this.bodyColor.levels[1] + 20,
+        this.bodyColor.levels[2] + 20
+      );
+      this.p.stroke(0, 0, 0, 80);
+      this.p.strokeWeight(2);
+      this.p.ellipse(s * 0.45, -s * 0.2, s * 0.5, s * 0.5);
+      this.p.noStroke();
+      this.p.fill(100, 255, 100);
+      this.p.ellipse(s * 0.45, -s * 0.2, s * 0.18);
+      this.p.fill(255);
+      this.p.ellipse(s * 0.48, -s * 0.18, s * 0.06);
+    }
 
     // SHORT STUMPY ANTENNAE (baby-like proportions)
     this.p.stroke(this.bodyColor);
@@ -328,6 +356,8 @@ class Grunt extends BaseEnemy {
       this.bodyColor.levels[2] + 30
     );
     this.p.rect(-s * 0.3, s * 0.1, s * 0.6, s * 0.08); // Simple belt
+
+    this.p.pop();
   }
 
   /**

--- a/packages/entities/src/Tank.js
+++ b/packages/entities/src/Tank.js
@@ -198,10 +198,26 @@ class Tank extends BaseEnemy {
    * Draw tank-specific body shape
    */
   drawBody(s) {
-    // Massive, blocky body
+    // Massive, blocky body with outline
     this.p.fill(this.bodyColor);
-    this.p.noStroke();
+    this.p.stroke(20, 20, 40, 100);
+    this.p.strokeWeight(2);
     this.p.rect(-s * 0.5, -s * 0.6, s, s * 1.2); // Main chassis (center part)
+    this.p.noStroke();
+
+    // Simple turret and barrel for a clearer silhouette
+    this.p.fill(
+      this.bodyColor.levels[0] + 30,
+      this.bodyColor.levels[1] + 30,
+      this.bodyColor.levels[2] + 30
+    );
+    this.p.rect(-s * 0.15, -s * 0.3, s * 0.3, s * 0.6); // Turret block
+    this.p.fill(
+      this.bodyColor.levels[0] - 20,
+      this.bodyColor.levels[1] - 20,
+      this.bodyColor.levels[2] - 20
+    );
+    this.p.rect(s * 0.15, -s * 0.05, s * 0.6, s * 0.1); // Cannon barrel
 
     // Decorative plating on main chassis (these are not the destructible armor)
     this.p.fill(

--- a/packages/entities/src/player.js
+++ b/packages/entities/src/player.js
@@ -55,7 +55,7 @@ export class Player {
     this.pantsColor = this.p.color(25, 25, 112); // Midnight blue pants
     this.skinColor = this.p.color(255, 219, 172); // Peach skin
     this.gunColor = this.p.color(169, 169, 169); // Dark gray gun
-    this.bandanaColor = this.p.color(139, 69, 19); // Brown bandana
+
 
     // Speech is now handled by unified Audio system
   }
@@ -371,12 +371,15 @@ export class Player {
       p.pop();
     }
 
-    // Draw head
+    // Draw head with subtle outline for definition
     p.fill(this.skinColor);
+    p.stroke(20);
+    p.strokeWeight(1);
     p.ellipse(0, -s * 0.25, s * 0.3);
+    p.noStroke();
 
     // Draw simple hair instead of bandana
-    p.fill(60, 40, 20); // Dark brown hair
+    p.fill(80, 50, 20); // Visible brown hair
     p.rect(-s * 0.18, -s * 0.38, s * 0.36, s * 0.12); // Hair on top
     p.rect(-s * 0.15, -s * 0.32, s * 0.08, s * 0.15); // Left sideburn
     p.rect(s * 0.07, -s * 0.32, s * 0.08, s * 0.15); // Right sideburn
@@ -392,16 +395,20 @@ export class Player {
     const lensW = eyeSize * 2.2; // Bigger for more character
     const lensH = eyeSize * 1.5; // Taller lenses
     
-    // Sunglasses frame
+    // Sunglasses frame with stronger outline
     p.fill(40, 40, 40); // Dark frame
+    p.stroke(10);
+    p.strokeWeight(2);
     p.rect(-lensW * 0.6, -s * 0.25 - lensH * 0.6, lensW * 1.2, lensH * 1.2); // Left frame
     p.rect(lensW * 0.6 - lensW * 1.2, -s * 0.25 - lensH * 0.6, lensW * 1.2, lensH * 1.2); // Right frame
-    
+    p.noStroke();
+
     // Bridge
+    p.fill(40, 40, 40);
     p.rect(-s * 0.03, -s * 0.25 - lensH * 0.2, s * 0.06, lensH * 0.4);
-    
+
     // Dark lenses
-    p.fill(5, 5, 15); // Very dark with slight blue tint
+    p.fill(15, 15, 25); // Very dark with slight blue tint
     p.ellipse(-eyeOffset, -s * 0.25, lensW, lensH); // Left lens
     p.ellipse(eyeOffset, -s * 0.25, lensW, lensH); // Right lens
     

--- a/packages/fx/src/PsychedelicEffects.js
+++ b/packages/fx/src/PsychedelicEffects.js
@@ -70,21 +70,26 @@ export class PsychedelicEffects {
    * Draw psychedelic space wormhole effect
    */
   drawCosmicWormhole(p, centerX, centerY, intensity = 1.0) {
+    if (intensity <= 0.01) return; // Skip heavy drawing when nearly invisible
+
     p.push();
     p.translate(centerX, centerY);
-    
+
+    // Dynamic detail based on intensity for performance scaling
+    const ringStep = 15 + (1 - intensity) * 10;
+    const segments = Math.floor(12 + intensity * 8);
+
     // Draw wormhole tunnel
-    for (let r = 300; r > 10; r -= 15) {
+    for (let r = 300; r > 10; r -= ringStep) {
       const colorPhase = this.cosmicTime + r * 0.01;
       const colorIndex = Math.floor((colorPhase * 2) % this.tripPalette.length);
       const color = this.tripPalette[colorIndex];
-      
-      const alpha = (300 - r) / 300 * 60 * intensity;
+
+      const alpha = ((300 - r) / 300) * 60 * intensity * 0.7; // More muted
       p.fill(color[0], color[1], color[2], alpha);
       p.noStroke();
-      
+
       // Warped circle
-      const segments = 20;
       p.beginShape();
       for (let i = 0; i <= segments; i++) {
         const angle = (i / segments) * TWO_PI;
@@ -96,23 +101,27 @@ export class PsychedelicEffects {
       }
       p.endShape(p.CLOSE);
     }
-    
+
     // Draw wormhole particles
-    this.wormholeParticles.forEach(particle => {
+    this.wormholeParticles.forEach((particle, idx) => {
+      // Skip some particles when intensity is low for performance
+      const skipFactor = Math.max(1, Math.floor(1 / intensity));
+      if (idx % skipFactor !== 0) return;
+
       const x = cos(particle.angle) * particle.radius;
       const y = sin(particle.angle) * particle.radius;
       const color = this.tripPalette[particle.colorIndex];
-      const alpha = (particle.life / particle.maxLife) * 150;
-      
+      const alpha = (particle.life / particle.maxLife) * 150 * intensity;
+
       p.fill(color[0], color[1], color[2], alpha);
       p.noStroke();
       p.ellipse(x, y, particle.size, particle.size);
-      
+
       // Trailing glow
       p.fill(color[0], color[1], color[2], alpha * 0.3);
       p.ellipse(x, y, particle.size * 2, particle.size * 2);
     });
-    
+
     p.pop();
   }
   

--- a/packages/fx/src/explosions/ExplosionManager.js
+++ b/packages/fx/src/explosions/ExplosionManager.js
@@ -49,7 +49,8 @@ class EnemyFragmentExplosion {
         this.enemy.type === 'grunt'
           ? random(4, 12) // Slower but bigger for grunts
           : random(3, 10); // Slower fragments for better visibility
-      const fragmentSize = random(size * 1.0, size * 2.5); // MASSIVE fragments for maximum visual impact
+      // Keep fragments roughly tied to enemy size so explosions match source
+      const fragmentSize = random(size * 0.4, size * 1.2);
 
       // Determine fragment type and color; for grunt use green palette exclusively
       let fragmentColor, fragmentType;
@@ -125,6 +126,7 @@ class EnemyFragmentExplosion {
   }
 
   createCentralExplosion() {
+    const size = this.enemy.size;
     // Create a much more dramatic explosion in the center using enemy colors
     // Extra particles for grunts to make them really satisfying to kill
     const particleCount = this.enemy.type === 'grunt' ? 40 : 25; // More particles for fuller central explosions
@@ -152,7 +154,7 @@ class EnemyFragmentExplosion {
         y: this.y,
         vx: cos(angle) * speed,
         vy: sin(angle) * speed,
-        size: random(25, 60), // HUGE particles for incredible visual impact
+        size: random(size * 0.3, size * 0.8), // Scale with enemy size for better proportion
         color: primaryColor,
         life: random(20, 40), // Shorter lifespan to ensure fade-out before probe
         maxLife: random(20, 40),

--- a/packages/systems/src/BackgroundRenderer.js
+++ b/packages/systems/src/BackgroundRenderer.js
@@ -542,20 +542,21 @@ export class BackgroundRenderer {
     
     // Cosmic wormhole effect in center during intense action (slower, more subtle)
     const enemyCount = this.gameState?.enemies?.length || 0;
-    const targetIntensity = enemyCount > 3 ? Math.min(enemyCount / 15, 0.8) : 0;
-    // Gradually interpolate towards target for smooth fade in/out
+    // Scale intensity gradually with enemy count to avoid hard threshold
+    const targetIntensity = p.constrain(enemyCount / 15, 0, 0.8);
+    // More gradual interpolation for smoother fade in/out
     this.wormholeIntensity = p.lerp(
       this.wormholeIntensity,
       targetIntensity,
-      0.05
+      0.02
     );
     if (this.wormholeIntensity > 0.01) {
       this.psychedelicEffects.drawCosmicWormhole(
         p,
         p.width / 2,
         p.height / 2,
-        this.wormholeIntensity * 0.15
-      ); // Even more subtle
+        this.wormholeIntensity * 0.1
+      ); // Muted appearance
     }
     
     // Kaleidoscope patterns around player when moving

--- a/packages/systems/src/CollisionSystem.js
+++ b/packages/systems/src/CollisionSystem.js
@@ -264,6 +264,8 @@ export class CollisionSystem {
     const killMethod = enemy.lastDamageSource || 'bullet';
     // Let VFXDispatcher handle particles/flash; ExplosionManager remains for its own internal visuals via other callers
     window.explosionManager?.addKillEffect?.(x, y, type, killMethod);
+    // Also spawn physical fragments (limbs, metal, etc.) based on enemy configuration
+    window.explosionManager?.addFragmentExplosion?.(x, y, enemy);
     // Dispatch VFX event for decoupled particles/flash
     try {
       window.dispatchEvent(

--- a/packages/systems/src/SpawnSystem.js
+++ b/packages/systems/src/SpawnSystem.js
@@ -176,13 +176,27 @@ export class SpawnSystem {
   }
 
   forceSpawn(enemyType, x, y) {
-    if (!window.gameState) return;
+    if (!window.gameState) return null;
     const gs = window.gameState;
     if (!gs.enemies) gs.enemies = [];
+
+    // If coordinates aren't provided, fall back to regular spawn placement
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      if (typeof this.findSpawnPosition === 'function') {
+        const pos = this.findSpawnPosition();
+        x = pos.x;
+        y = pos.y;
+      } else {
+        x = 0;
+        y = 0;
+      }
+    }
+
     const enemy = this.enemyFactory.createEnemy(x, y, enemyType);
     gs.enemies.push(enemy);
     console.log(
       `👾 Force-spawned ${enemyType} at (${x.toFixed(1)}, ${y.toFixed(1)})`
     );
+    return enemy;
   }
 }

--- a/packages/systems/src/UIRenderer.js
+++ b/packages/systems/src/UIRenderer.js
@@ -529,6 +529,28 @@ export class UIRenderer {
       }
     }
 
+    // Developer enemy spawn shortcuts (keys 1-4)
+    if (['1', '2', '3', '4'].includes(key)) {
+      const typeMap = { 1: 'grunt', 2: 'rusher', 3: 'tank', 4: 'stabber' };
+      const spawnType = typeMap[key];
+      if (window.spawnSystem && spawnType) {
+        // Use spawn system's spawn logic to find a good position
+        let pos = { x: 0, y: 0 };
+        if (typeof window.spawnSystem.findSpawnPosition === 'function') {
+          pos = window.spawnSystem.findSpawnPosition();
+        } else if (this.player) {
+          // Fallback: spawn near player if no finder available
+          pos = { x: this.player.x + 60, y: this.player.y };
+        }
+        if (typeof window.spawnSystem.forceSpawn === 'function') {
+          window.spawnSystem.forceSpawn(spawnType, pos.x, pos.y);
+          console.log(`👾 Manual spawn: ${spawnType}`);
+          this._showToast(`Spawned ${spawnType}`);
+          return true;
+        }
+      }
+    }
+
     // Arrow keys for aim direction
     if (this.gameState.gameState === 'playing' && this.player) {
       if (key === 'ArrowUp') {


### PR DESCRIPTION
## Summary
- Scale enemy death explosions with enemy size for better proportion
- Realign grunt graphics so hitbox matches visuals
- Raise rusher and stabber speech and move volumes to config for easy tuning
- Outline player and enemy sprites; remove player bandana and add clearer sunglasses
- Add turret and barrel details to tank sprites
- Fade in/out optimized wormhole visual and align collision logic with bullet radius
- Add debug hotkeys 1–4 to spawn grunt, rusher, tank and stabber
- Let `forceSpawn` choose a spawn position when coordinates aren’t provided

## Testing
- `npm run lint` (fails: Parsing error: Unexpected token ,)
- `npm test` (fails: script "test:playwright" exited with code 1)


------
https://chatgpt.com/codex/tasks/task_e_68a1b23bbc84832ab4392b3e89869d31