### PR TITLE
Hide dev spawn instructions and cleanup progress meter

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
         z-index: 101;
         pointer-events: none;
         line-height: 1.5;
+        display: none;
       "
     >
       <div><b>Enemy Spawn Keys</b></div>

--- a/packages/systems/src/HudRenderer.js
+++ b/packages/systems/src/HudRenderer.js
@@ -32,27 +32,6 @@ export class HudRenderer {
     p.text(healthTxt, 10, 28);
     p.text(levelTxt, 10, 46);
 
-    // Level progress bar
-    const progress = this.gameState.getProgressToNextLevel?.() ?? 0;
-    const barWidth = 120;
-    const barHeight = 8;
-    const barX = 10;
-    const barY = 64;
-
-    // Background bar
-    p.fill(50, 50, 50, 150);
-    p.rect(barX, barY, barWidth, barHeight);
-
-    // Progress fill
-    p.fill(100, 255, 100, 200);
-    p.rect(barX, barY, barWidth * progress, barHeight);
-
-    // Border
-    p.stroke(255, 255, 255, 100);
-    p.strokeWeight(1);
-    p.noFill();
-    p.rect(barX, barY, barWidth, barHeight);
-
     p.pop();
   }
 }

--- a/packages/systems/src/UIRenderer.js
+++ b/packages/systems/src/UIRenderer.js
@@ -620,6 +620,10 @@ export class UIRenderer {
     this.devMode = !this.devMode;
     console.log(`🛠️ Dev mode ${this.devMode ? 'ENABLED' : 'DISABLED'}`);
     this._showToast(`Dev mode ${this.devMode ? 'ON' : 'OFF'}`);
+    const spawnEl = document.getElementById('spawnInstructions');
+    if (spawnEl) {
+      spawnEl.style.display = this.devMode ? 'block' : 'none';
+    }
     if (this.devMode) {
       if (!this.settingsMenu) {
         const p = window.p5?.instance;


### PR DESCRIPTION
## Summary
- Hide enemy spawn shortcut list until developer mode is enabled
- Show or hide spawn instructions when toggling dev mode
- Remove redundant HUD progress bar so level meter renders unobstructed on the right

## Testing
- `bun test` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68a208316250832a9b1ea7d6a55bb7f2